### PR TITLE
Ability to use unix socket for connection to nsqd

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -422,20 +422,22 @@ func (c *Conn) identify() (*IdentifyResponse, error) {
 }
 
 func (c *Conn) upgradeTLS(tlsConf *tls.Config) error {
-	host, _, err := net.SplitHostPort(c.addr)
-	if err != nil {
-		return err
-	}
 
 	// create a local copy of the config to set ServerName for this connection
 	conf := &tls.Config{}
 	if tlsConf != nil {
 		conf = tlsConf.Clone()
 	}
-	conf.ServerName = host
+	if c.socketType == "tcp" {
+		host, _, err := net.SplitHostPort(c.addr)
+		if err != nil {
+			return err
+		}
+		conf.ServerName = host
+	}
 
 	c.tlsConn = tls.Client(c.conn, conf)
-	err = c.tlsConn.Handshake()
+	err := c.tlsConn.Handshake()
 	if err != nil {
 		return err
 	}

--- a/conn.go
+++ b/conn.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -59,9 +61,10 @@ type Conn struct {
 
 	config *Config
 
-	conn    *net.TCPConn
-	tlsConn *tls.Conn
-	addr    string
+	conn       net.Conn
+	tlsConn    *tls.Conn
+	addr       string
+	socketType string
 
 	delegate ConnDelegate
 
@@ -90,8 +93,13 @@ func NewConn(addr string, config *Config, delegate ConnDelegate) *Conn {
 	if !config.initialized {
 		panic("Config must be created with NewConfig()")
 	}
+	socketType := "tcp"
+	if isSocket(addr) {
+		socketType = "unix"
+	}
 	return &Conn{
-		addr: addr,
+		addr:       addr,
+		socketType: socketType,
 
 		config:   config,
 		delegate: delegate,
@@ -119,8 +127,7 @@ func NewConn(addr string, config *Config, delegate ConnDelegate) *Conn {
 // The logger parameter is an interface that requires the following
 // method to be implemented (such as the the stdlib log.Logger):
 //
-//    Output(calldepth int, s string)
-//
+//	Output(calldepth int, s string)
 func (c *Conn) SetLogger(l logger, lvl LogLevel, format string) {
 	c.logGuard.Lock()
 	defer c.logGuard.Unlock()
@@ -176,11 +183,11 @@ func (c *Conn) Connect() (*IdentifyResponse, error) {
 		Timeout:   c.config.DialTimeout,
 	}
 
-	conn, err := dialer.Dial("tcp", c.addr)
+	conn, err := dialer.Dial(c.socketType, c.addr)
 	if err != nil {
 		return nil, err
 	}
-	c.conn = conn.(*net.TCPConn)
+	c.conn = conn
 	c.r = conn
 	c.w = conn
 
@@ -218,7 +225,7 @@ func (c *Conn) Connect() (*IdentifyResponse, error) {
 func (c *Conn) Close() error {
 	atomic.StoreInt32(&c.closeFlag, 1)
 	if c.conn != nil && atomic.LoadInt64(&c.messagesInFlight) == 0 {
-		return c.conn.CloseRead()
+		return c.conn.Close()
 	}
 	return nil
 }
@@ -666,7 +673,7 @@ func (c *Conn) close() {
 	c.stopper.Do(func() {
 		c.log(LogLevelInfo, "beginning close")
 		close(c.exitChan)
-		c.conn.CloseRead()
+		c.conn.Close()
 
 		c.wg.Add(1)
 		go c.cleanup()
@@ -720,7 +727,7 @@ func (c *Conn) waitForCleanup() {
 	// this blocks until readLoop and writeLoop
 	// (and cleanup goroutine above) have exited
 	c.wg.Wait()
-	c.conn.CloseWrite()
+	c.conn.Close()
 	c.log(LogLevelInfo, "clean close complete")
 	c.delegate.OnClose(c)
 }
@@ -762,4 +769,12 @@ func (c *Conn) log(lvl LogLevel, line string, args ...interface{}) {
 	logger.Output(2, fmt.Sprintf("%-4s %s %s", lvl,
 		fmt.Sprintf(logFmt, c.String()),
 		fmt.Sprintf(line, args...)))
+}
+
+func isSocket(path string) bool {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return fileInfo.Mode().Type() == fs.ModeSocket
 }

--- a/consumer_unix_socket_test.go
+++ b/consumer_unix_socket_test.go
@@ -1,0 +1,193 @@
+package nsq
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func SendMessageToUnixSocket(t *testing.T, addr string, topic string, method string, body []byte) {
+	httpclient := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", addr)
+			},
+		},
+	}
+
+	endpoint := fmt.Sprintf("http://unix/%s?topic=%s", method, topic)
+	resp, err := httpclient.Post(endpoint, "application/octet-stream", bytes.NewBuffer(body))
+	if err != nil {
+		t.Fatalf(err.Error())
+		return
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("%s status code: %d", method, resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestUnixSocketConsumer(t *testing.T) {
+	consumerUnixSocketTest(t, nil)
+}
+
+func TestUnixSocketConsumerTLS(t *testing.T) {
+	consumerUnixSocketTest(t, func(c *Config) {
+		c.TlsV1 = true
+		c.TlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	})
+}
+
+func TestUnixSocketConsumerDeflate(t *testing.T) {
+	consumerUnixSocketTest(t, func(c *Config) {
+		c.Deflate = true
+	})
+}
+
+func TestUnixSocketConsumerSnappy(t *testing.T) {
+	consumerUnixSocketTest(t, func(c *Config) {
+		c.Snappy = true
+	})
+}
+
+func TestUnixSocketConsumerTLSDeflate(t *testing.T) {
+	consumerUnixSocketTest(t, func(c *Config) {
+		c.TlsV1 = true
+		c.TlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		c.Deflate = true
+	})
+}
+
+func TestUnixSocketConsumerTLSSnappy(t *testing.T) {
+	consumerUnixSocketTest(t, func(c *Config) {
+		c.TlsV1 = true
+		c.TlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		c.Snappy = true
+	})
+}
+
+func TestUnixSocketConsumerTLSClientCert(t *testing.T) {
+	cert, _ := tls.LoadX509KeyPair("./test/client.pem", "./test/client.key")
+	consumerUnixSocketTest(t, func(c *Config) {
+		c.TlsV1 = true
+		c.TlsConfig = &tls.Config{
+			Certificates:       []tls.Certificate{cert},
+			InsecureSkipVerify: true,
+		}
+	})
+}
+
+func TestUnixSocketConsumerTLSClientCertViaSet(t *testing.T) {
+	consumerUnixSocketTest(t, func(c *Config) {
+		c.Set("tls_v1", true)
+		c.Set("tls_cert", "./test/client.pem")
+		c.Set("tls_key", "./test/client.key")
+		c.Set("tls_insecure_skip_verify", true)
+	})
+}
+
+func consumerUnixSocketTest(t *testing.T, cb func(c *Config)) {
+	// unix addresses of nsqd are specified in test.sh
+	addr := "/tmp/nsqd.sock"
+	httpAddr := "/tmp/nsqd-http.sock"
+
+	config := NewConfig()
+
+	config.DefaultRequeueDelay = 0
+	// so that the test won't timeout from backing off
+	config.MaxBackoffDuration = time.Millisecond * 50
+	if cb != nil {
+		cb(config)
+	}
+	topicName := "rdr_test"
+	if config.Deflate {
+		topicName = topicName + "_deflate"
+	} else if config.Snappy {
+		topicName = topicName + "_snappy"
+	}
+	if config.TlsV1 {
+		topicName = topicName + "_tls"
+	}
+	topicName = topicName + strconv.Itoa(int(time.Now().Unix()))
+	q, _ := NewConsumer(topicName, "ch", config)
+	q.SetLogger(newTestLogger(t), LogLevelDebug)
+
+	h := &MyTestHandler{
+		t: t,
+		q: q,
+	}
+	q.AddHandler(h)
+
+	SendMessageToUnixSocket(t, httpAddr, topicName, "pub", []byte(`{"msg":"single"}`))
+	SendMessageToUnixSocket(t, httpAddr, topicName, "mpub", []byte("{\"msg\":\"double\"}\n{\"msg\":\"double\"}"))
+	SendMessageToUnixSocket(t, httpAddr, topicName, "pub", []byte("TOBEFAILED"))
+	h.messagesSent = 4
+
+	err := q.ConnectToNSQD(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stats := q.Stats()
+	if stats.Connections == 0 {
+		t.Fatal("stats report 0 connections (should be > 0)")
+	}
+
+	err = q.ConnectToNSQD(addr)
+	if err == nil {
+		t.Fatal("should not be able to connect to the same NSQ twice")
+	}
+
+	conn := q.conns()[0]
+	if conn.String() != addr {
+		t.Fatal("connection should be bound to the specified address:", addr)
+	}
+
+	err = q.DisconnectFromNSQD("/tmp/doesntexist.sock")
+	if err == nil {
+		t.Fatal("should not be able to disconnect from an unknown nsqd")
+	}
+
+	err = q.ConnectToNSQD("/tmp/doesntexist.sock")
+	if err == nil {
+		t.Fatal("should not be able to connect to non-existent nsqd")
+	}
+
+	err = q.DisconnectFromNSQD("/tmp/doesntexist.sock")
+	if err != nil {
+		t.Fatal("should be able to disconnect from an nsqd - " + err.Error())
+	}
+
+	<-q.StopChan
+
+	stats = q.Stats()
+	if stats.Connections != 0 {
+		t.Fatalf("stats report %d active connections (should be 0)", stats.Connections)
+	}
+
+	stats = q.Stats()
+	if stats.MessagesReceived != uint64(h.messagesReceived+h.messagesFailed) {
+		t.Fatalf("stats report %d messages received (should be %d)",
+			stats.MessagesReceived,
+			h.messagesReceived+h.messagesFailed)
+	}
+
+	if h.messagesReceived != 8 || h.messagesSent != 4 {
+		t.Fatalf("end of test. should have handled a diff number of messages (got %d, sent %d)", h.messagesReceived, h.messagesSent)
+	}
+	if h.messagesFailed != 1 {
+		t.Fatal("failed message not done")
+	}
+}

--- a/producer_unix_socket_test.go
+++ b/producer_unix_socket_test.go
@@ -1,0 +1,342 @@
+package nsq
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestUnixSocketProducerConnection(t *testing.T) {
+	config := NewConfig()
+
+	w, _ := NewProducer("/tmp/nsqd.sock", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+
+	err := w.Publish("write_test", []byte("test"))
+	if err != nil {
+		t.Fatalf("should lazily connect - %s", err)
+	}
+
+	w.Stop()
+
+	err = w.Publish("write_test", []byte("fail test"))
+	if err != ErrStopped {
+		t.Fatalf("should not be able to write after Stop()")
+	}
+}
+
+func TestUnixSocketProducerPing(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	config := NewConfig()
+	w, _ := NewProducer("/tmp/nsqd.sock", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+
+	err := w.Ping()
+
+	if err != nil {
+		t.Fatalf("should connect on ping")
+	}
+
+	w.Stop()
+
+	err = w.Ping()
+	if err != ErrStopped {
+		t.Fatalf("should not be able to ping after Stop()")
+	}
+}
+
+func TestUnixSocketProducerPublish(t *testing.T) {
+	topicName := "publish" + strconv.Itoa(int(time.Now().Unix()))
+	msgCount := 10
+
+	config := NewConfig()
+	w, _ := NewProducer("/tmp/nsqd.sock", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+	defer w.Stop()
+
+	for i := 0; i < msgCount; i++ {
+		err := w.Publish(topicName, []byte("publish_test_case"))
+		if err != nil {
+			t.Fatalf("error %s", err)
+		}
+	}
+
+	err := w.Publish(topicName, []byte("bad_test_case"))
+	if err != nil {
+		t.Fatalf("error %s", err)
+	}
+
+	readMessagesFromUnixSocket(topicName, t, msgCount)
+}
+
+func TestUnixSocketProducerMultiPublish(t *testing.T) {
+	topicName := "multi_publish" + strconv.Itoa(int(time.Now().Unix()))
+	msgCount := 10
+
+	config := NewConfig()
+	w, _ := NewProducer("/tmp/nsqd.sock", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+	defer w.Stop()
+
+	var testData [][]byte
+	for i := 0; i < msgCount; i++ {
+		testData = append(testData, []byte("multipublish_test_case"))
+	}
+
+	err := w.MultiPublish(topicName, testData)
+	if err != nil {
+		t.Fatalf("error %s", err)
+	}
+
+	err = w.Publish(topicName, []byte("bad_test_case"))
+	if err != nil {
+		t.Fatalf("error %s", err)
+	}
+
+	readMessagesFromUnixSocket(topicName, t, msgCount)
+}
+
+func TestUnixSocketProducerPublishAsync(t *testing.T) {
+	topicName := "async_publish" + strconv.Itoa(int(time.Now().Unix()))
+	msgCount := 10
+
+	config := NewConfig()
+	w, _ := NewProducer("/tmp/nsqd.sock", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+	defer w.Stop()
+
+	responseChan := make(chan *ProducerTransaction, msgCount)
+	for i := 0; i < msgCount; i++ {
+		err := w.PublishAsync(topicName, []byte("publish_test_case"), responseChan, "test")
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+
+	for i := 0; i < msgCount; i++ {
+		trans := <-responseChan
+		if trans.Error != nil {
+			t.Fatalf(trans.Error.Error())
+		}
+		if trans.Args[0].(string) != "test" {
+			t.Fatalf(`proxied arg "%s" != "test"`, trans.Args[0].(string))
+		}
+	}
+
+	err := w.Publish(topicName, []byte("bad_test_case"))
+	if err != nil {
+		t.Fatalf("error %s", err)
+	}
+
+	readMessagesFromUnixSocket(topicName, t, msgCount)
+}
+
+func TestUnixSocketProducerMultiPublishAsync(t *testing.T) {
+	topicName := "multi_publish" + strconv.Itoa(int(time.Now().Unix()))
+	msgCount := 10
+
+	config := NewConfig()
+	w, _ := NewProducer("/tmp/nsqd.sock", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+	defer w.Stop()
+
+	var testData [][]byte
+	for i := 0; i < msgCount; i++ {
+		testData = append(testData, []byte("multipublish_test_case"))
+	}
+
+	responseChan := make(chan *ProducerTransaction)
+	err := w.MultiPublishAsync(topicName, testData, responseChan, "test0", 1)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	trans := <-responseChan
+	if trans.Error != nil {
+		t.Fatalf(trans.Error.Error())
+	}
+	if trans.Args[0].(string) != "test0" {
+		t.Fatalf(`proxied arg "%s" != "test0"`, trans.Args[0].(string))
+	}
+	if trans.Args[1].(int) != 1 {
+		t.Fatalf(`proxied arg %d != 1`, trans.Args[1].(int))
+	}
+
+	err = w.Publish(topicName, []byte("bad_test_case"))
+	if err != nil {
+		t.Fatalf("error %s", err)
+	}
+
+	readMessagesFromUnixSocket(topicName, t, msgCount)
+}
+
+func TestUnixSocketProducerHeartbeat(t *testing.T) {
+	topicName := "heartbeat" + strconv.Itoa(int(time.Now().Unix()))
+
+	config := NewConfig()
+	config.HeartbeatInterval = 100 * time.Millisecond
+	w, _ := NewProducer("/tmp/nsqd.sock", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+	defer w.Stop()
+
+	err := w.Publish(topicName, []byte("publish_test_case"))
+	if err == nil {
+		t.Fatalf("error should not be nil")
+	}
+	if identifyError, ok := err.(ErrIdentify); !ok ||
+		identifyError.Reason != "E_BAD_BODY IDENTIFY heartbeat interval (100) is invalid" {
+		t.Fatalf("wrong error - %s", err)
+	}
+
+	config = NewConfig()
+	config.HeartbeatInterval = 1000 * time.Millisecond
+	w, _ = NewProducer("/tmp/nsqd.sock", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+	defer w.Stop()
+
+	err = w.Publish(topicName, []byte("publish_test_case"))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+
+	msgCount := 10
+	for i := 0; i < msgCount; i++ {
+		err := w.Publish(topicName, []byte("publish_test_case"))
+		if err != nil {
+			t.Fatalf("error %s", err)
+		}
+	}
+
+	err = w.Publish(topicName, []byte("bad_test_case"))
+	if err != nil {
+		t.Fatalf("error %s", err)
+	}
+
+	readMessagesFromUnixSocket(topicName, t, msgCount+1)
+}
+
+func readMessagesFromUnixSocket(topicName string, t *testing.T, msgCount int) {
+	config := NewConfig()
+	config.DefaultRequeueDelay = 0
+	config.MaxBackoffDuration = 50 * time.Millisecond
+	q, _ := NewConsumer(topicName, "ch", config)
+	q.SetLogger(nullLogger, LogLevelInfo)
+
+	h := &ConsumerHandler{
+		t: t,
+		q: q,
+	}
+	q.AddHandler(h)
+
+	err := q.ConnectToNSQD("/tmp/nsqd.sock")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	<-q.StopChan
+
+	if h.messagesGood != msgCount {
+		t.Fatalf("end of test. should have handled a diff number of messages %d != %d", h.messagesGood, msgCount)
+	}
+
+	if h.messagesFailed != 1 {
+		t.Fatal("failed message not done")
+	}
+}
+
+type mockProducerUnixSocketConn struct {
+	delegate ConnDelegate
+	closeCh  chan struct{}
+	pubCh    chan struct{}
+}
+
+func newMockProducerUnixSocketConn(delegate ConnDelegate) producerConn {
+	m := &mockProducerUnixSocketConn{
+		delegate: delegate,
+		closeCh:  make(chan struct{}),
+		pubCh:    make(chan struct{}, 4),
+	}
+	go m.router()
+	return m
+}
+
+func (m *mockProducerUnixSocketConn) String() string {
+	return "/tmp/nsqd.sock"
+}
+
+func (m *mockProducerUnixSocketConn) SetLogger(logger logger, level LogLevel, prefix string) {}
+
+func (m *mockProducerUnixSocketConn) SetLoggerLevel(lvl LogLevel) {}
+
+func (m *mockProducerUnixSocketConn) SetLoggerForLevel(logger logger, level LogLevel, format string) {
+}
+
+func (m *mockProducerUnixSocketConn) Connect() (*IdentifyResponse, error) {
+	return &IdentifyResponse{}, nil
+}
+
+func (m *mockProducerUnixSocketConn) Close() error {
+	close(m.closeCh)
+	return nil
+}
+
+func (m *mockProducerUnixSocketConn) WriteCommand(cmd *Command) error {
+	if bytes.Equal(cmd.Name, []byte("PUB")) {
+		m.pubCh <- struct{}{}
+	}
+	return nil
+}
+
+func (m *mockProducerUnixSocketConn) router() {
+	for {
+		select {
+		case <-m.closeCh:
+			goto exit
+		case <-m.pubCh:
+			m.delegate.OnResponse(nil, framedResponse(FrameTypeResponse, []byte("OK")))
+		}
+	}
+exit:
+}
+
+func BenchmarkUnixSocketProducer(b *testing.B) {
+	b.StopTimer()
+	body := make([]byte, 512)
+
+	config := NewConfig()
+	p, _ := NewProducer("/tmp/nsqd.sock", config)
+
+	p.conn = newMockProducerUnixSocketConn(&producerConnDelegate{p})
+	atomic.StoreInt32(&p.state, StateConnected)
+	p.closeChan = make(chan int)
+	go p.router()
+
+	startCh := make(chan struct{})
+	var wg sync.WaitGroup
+	parallel := runtime.GOMAXPROCS(0)
+
+	for j := 0; j < parallel; j++ {
+		wg.Add(1)
+		go func() {
+			<-startCh
+			for i := 0; i < b.N/parallel; i++ {
+				p.Publish("test", body)
+			}
+			wg.Done()
+		}()
+	}
+
+	b.StartTimer()
+	close(startCh)
+	wg.Wait()
+}

--- a/test.sh
+++ b/test.sh
@@ -4,11 +4,11 @@ set -e
 # a helper script to run tests
 
 if ! which nsqd >/dev/null; then
-    echo "missing nsqd binary" && exit 1
+  echo "missing nsqd binary" && exit 1
 fi
 
 if ! which nsqlookupd >/dev/null; then
-    echo "missing nsqlookupd binary" && exit 1
+  echo "missing nsqlookupd binary" && exit 1
 fi
 
 # run nsqlookupd
@@ -26,13 +26,25 @@ echo "  logging to $NSQD_LOGFILE"
 nsqd --data-path=/tmp --lookupd-tcp-address=127.0.0.1:4160 --tls-cert=./test/server.pem --tls-key=./test/server.key --tls-root-ca-file=./test/ca.pem >$NSQD_LOGFILE 2>&1 &
 NSQD_PID=$!
 
+NSQD_UNIX_SOCKET_LOGFILE=$(mktemp -t nsqlookupd.XXXXXXX)
+NSQD_UNIX_SOCKET_DATA_PATH=$(mktemp -d tmp.XXXXXXX)
+echo "starting nsqd with unix socket --use-unix-sockets --tcp-address /tmp/nsqd.sock --https-address /tmp/nsqd-https.sock --data-path=$NSQD_UNIX_SOCKET_DATA_PATH --tls-cert=./test/server.pem --tls-key=./test/server.key --tls-root-ca-file=./test/ca.pem"
+echo "  logging to $NSQD_UNIX_SOCKET_LOGFILE"
+nsqd --use-unix-sockets --tcp-address /tmp/nsqd.sock --http-address /tmp/nsqd-http.sock --https-address /tmp/nsqd-https.sock --data-path=$NSQD_UNIX_SOCKET_DATA_PATH --tls-cert=./test/server.pem --tls-key=./test/server.key --tls-root-ca-file=./test/ca.pem >$NSQD_UNIX_SOCKET_LOGFILE 2>&1 &
+NSQD_UNIX_SOCKET_PID=$!
+
 sleep 0.3
 
 cleanup() {
-    echo "killing nsqd PID $NSQD_PID"
-    kill -s TERM $NSQD_PID || cat $NSQD_LOGFILE
-    echo "killing nsqlookupd PID $LOOKUPD_PID"
-    kill -s TERM $LOOKUPD_PID || cat $LOOKUP_LOGFILE
+  echo "killing nsqd PID $NSQD_PID"
+  kill -s TERM $NSQD_PID || cat $NSQD_LOGFILE
+  echo "killing nsqd unix socket PID $NSQD_UNIX_SOCKET_PID"
+  kill -s TERM $NSQD_UNIX_SOCKET_PID || cat $NSQD_LOGFILE
+  echo "killing nsqlookupd PID $LOOKUPD_PID"
+  kill -s TERM $LOOKUPD_PID || cat $LOOKUP_LOGFILE
+
+  rm -f /tmp/nsqd.sock
+  rm -f /tmp/nsqd-https.sock
 }
 trap cleanup INT TERM EXIT
 


### PR DESCRIPTION
Example to use reader:
```
	consumer, _ := nsq.NewConsumer(stream, group, nsq.NewConfig())
	if err = consumer.ConnectToNSQD("/var/run/nsqd.sock"); err != nil {
		logger.Error("failed to connect to nsqd: ", err)
		return
	}
```
and writer:
```
	nsq.NewProducer("/var/run/nsqd.sock", cfg)
```
with connection to nsqd via unix sockets.